### PR TITLE
refactor: move react scripts to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkify",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "license": "MIT",
   "description": "An awesome lightweight React UI Component library",
   "repository": "https://github.com/Trendyol/quarkify",
@@ -32,7 +32,6 @@
     "node-sass": "^4.12.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-scripts": "3.0.1",
     "react-transition-group": "^4.2.0"
   },
   "devDependencies": {
@@ -50,6 +49,7 @@
     "faker": "^4.1.0",
     "husky": "^3.0.0",
     "lint-staged": "^9.1.0",
+    "react-scripts": "3.0.1",
     "sinon": "^7.3.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.0.4",


### PR DESCRIPTION
It moves react-scripts package to dev dependencies so it won't be included at user dependencies