### PR TITLE
Add children types for React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quarkify",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quarkify",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/jest": "24.0.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkify",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "An awesome lightweight React UI Component library",
   "repository": "https://github.com/Trendyol/quarkify",

--- a/src/components/accordion/accordion-content.tsx
+++ b/src/components/accordion/accordion-content.tsx
@@ -24,7 +24,8 @@ export default class Content extends PureComponent<IAccordionContentProps> {
 
 interface IAccordionContentProps extends IDiv {
   animation?: animationTypes;
-  onChange?: () => void;
   className?: string;
   expanded?: boolean;
+  children?: React.ReactNode;
+  onChange?: () => void;
 }

--- a/src/components/accordion/accordion-group.tsx
+++ b/src/components/accordion/accordion-group.tsx
@@ -23,4 +23,5 @@ export default class AccordionGroup extends PureComponent<IAccordionGroupProps> 
 
 // tslint:disable-next-line:no-empty-interface
 interface IAccordionGroupProps extends IDiv {
+  children?: React.ReactNode;
 }

--- a/src/components/accordion/accordion-header.tsx
+++ b/src/components/accordion/accordion-header.tsx
@@ -25,6 +25,7 @@ export default  class Header extends PureComponent<IHeaderProps> {
 export interface IHeaderProps extends IDiv {
   icon?: string;
   expanded?: boolean;
-  handleClick?: () => void;
   className?: string;
+  children?: React.ReactNode;
+  handleClick?: () => void;
 }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -63,6 +63,7 @@ export default class Accordion extends PureComponent<IAccordionProps, IAccordion
 interface IAccordionProps {
   className?: string;
   expanded?: boolean;
+  children?: React.ReactNode;
   onChange?: (expanded: boolean) => void;
 }
 

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -35,4 +35,5 @@ interface IBadgeProps extends IDiv {
   className?: string;
   color?: colorTypes;
   icon?: string;
+  children?: React.ReactNode;
 }

--- a/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { PureComponent, ReactNode } from "react";
+import React, { PureComponent } from "react";
 import { CSSTransition } from "react-transition-group";
 
 export default class BottomSheet extends PureComponent<
@@ -131,7 +131,7 @@ export default class BottomSheet extends PureComponent<
 
 interface IBottomSheetProps {
   show: boolean;
-  children?: ReactNode;
+  children?: React.ReactNode;
   onChange?: (status: boolean) => void;
   className?: string;
   onClose: () => void;

--- a/src/components/box/box-group.tsx
+++ b/src/components/box/box-group.tsx
@@ -23,4 +23,5 @@ export default class BoxGroup extends PureComponent<IBoxGroupProps> {
 
 // tslint:disable-next-line:no-empty-interface
 interface IBoxGroupProps extends IDiv {
+    children?: React.ReactNode;
 }

--- a/src/components/box/box.tsx
+++ b/src/components/box/box.tsx
@@ -31,4 +31,5 @@ interface IBoxProps extends IDiv {
     fitted?: boolean;
     textAlign?: textAlignTypes;
     className?: string;
+    children?: React.ReactNode;
 }

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -46,4 +46,5 @@ export interface IProps extends IIcon {
   onClick?: (event: any) => any;
   stroke?: number;
   className?: string;
+  children?: React.ReactNode;
 }

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -31,4 +31,5 @@ export default class Layout extends PureComponent<ILayoutProps> {
 interface ILayoutProps extends IDiv {
   fitted?: boolean;
   fullScreen?: boolean;
+  children?: React.ReactNode;
 }

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -59,4 +59,5 @@ interface ILinkProps extends ILink {
   className?: string;
   loading?: boolean;
   to: string;
+  children?: React.ReactNode;
 }

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -29,4 +29,5 @@ export default class List extends PureComponent<IListProps> {
 interface IListProps extends IList {
   noDot?: boolean;
   className?: string;
+  children?: React.ReactNode;
 }

--- a/src/components/list/listItem.tsx
+++ b/src/components/list/listItem.tsx
@@ -30,4 +30,5 @@ interface IItemProps extends IListItem {
   icon?: string;
   iconColor?: colorTypes;
   className?: string;
+  children?: React.ReactNode;
 }

--- a/src/components/modal/modal-actions.tsx
+++ b/src/components/modal/modal-actions.tsx
@@ -1,8 +1,12 @@
 import React, { PureComponent } from "react";
 
-export default class Actions extends PureComponent {
+export default class Actions extends PureComponent<IActionsProps> {
   public render() {
     const {children} = this.props;
     return <div className="q-modal-actions">{children}</div>;
   }
+}
+
+interface IActionsProps {
+  children?: React.ReactNode;
 }

--- a/src/components/modal/modal-content.tsx
+++ b/src/components/modal/modal-content.tsx
@@ -9,4 +9,5 @@ export default class Content extends PureComponent<IModalContentProps> {
 
 interface IModalContentProps {
   className?: string;
+  children?: React.ReactNode;
 }

--- a/src/components/modal/modal-header.tsx
+++ b/src/components/modal/modal-header.tsx
@@ -30,6 +30,7 @@ export interface IHeaderProps {
   leftIcon?: string;
   rightIcon?: string;
   className?: string;
+  children?: React.ReactNode;
   leftIconOnClick?: (event: any) => any;
   rightIconOnClick?: (event: any) => any;
 }

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { ReactNode } from "react";
+import React from "react";
 import { CSSTransition } from "react-transition-group";
 import { animationTypes } from "../../types/modal";
 import Actions from "./modal-actions";
@@ -54,7 +54,7 @@ export default class Modal extends React.Component<IModalProps> {
 interface IModalProps {
   show: boolean;
   animation?: animationTypes;
-  children?: ReactNode;
+  children?: React.ReactNode;
   onChange?: () => void;
   className?: string;
 }

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -1,10 +1,10 @@
 import classNames from "classnames";
-import React, { PureComponent } from "react";
+import React, { PropsWithChildren, PureComponent } from "react";
 import ReactDOM from "react-dom";
 import { CSSTransition } from "react-transition-group";
 import Icon from "../icon";
 
-export default class Popup extends PureComponent<IPopupProps, IPopupState> {
+export default class Popup extends PureComponent<PropsWithChildren<IPopupProps>, IPopupState> {
   constructor(props: IPopupProps) {
     super(props);
     this.handleTouchMove = this.handleTouchMove.bind(this);
@@ -181,6 +181,7 @@ interface IPopupProps {
   contentClassName?: string;
   title?: React.ReactElement | string;
   withTitleBorder?: boolean;
+  children?: React.ReactNode;
 }
 
 interface IPopupState {

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -64,4 +64,5 @@ interface IProps extends IDiv {
   className?: string;
   margin?: number;
   stars?: number;
+  children?: React.ReactNode;
 }

--- a/src/components/ripple/ripple.tsx
+++ b/src/components/ripple/ripple.tsx
@@ -114,7 +114,7 @@ export interface IRipplesProps {
   color?: string;
   className?: string;
   children?: React.ReactNode;
-  onClick?: (event: React.MouseEvent<HTMLDivElement>) => any;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 type IRippleState = Readonly<{

--- a/src/components/ripple/ripple.tsx
+++ b/src/components/ripple/ripple.tsx
@@ -112,8 +112,9 @@ export interface IRipplesProps {
   during?: number;
   display?: string;
   color?: string;
-  onClick?: (event: React.MouseEvent<HTMLDivElement>) => any;
   className?: string;
+  children?: React.ReactNode;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => any;
 }
 
 type IRippleState = Readonly<{

--- a/src/components/step-progress-bar/step-progress-bar.tsx
+++ b/src/components/step-progress-bar/step-progress-bar.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { PureComponent, ReactNode } from "react";
+import React, { PureComponent } from "react";
 import IList from "../../interfaces/list";
 import { colorTypes } from "../../types/color";
 
@@ -28,6 +28,6 @@ export default class StepProgressBar extends PureComponent<IProps> {
 
 interface IProps extends IList {
   color?: colorTypes;
-  children: ReactNode;
+  children?: React.ReactNode;
   className?: string;
 }

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -6,7 +6,7 @@ import { displayTypes, variantTypes } from "../../types/typography";
 import classNamesDefault from "../../utils/class-names-default";
 
 export default class Typography extends PureComponent<ITypographyProps> {
-
+  
   public render() {
     const {
       variant,
@@ -57,4 +57,5 @@ interface ITypographyProps extends ITypography {
   display?: displayTypes;
   color?: colorTypes;
   className?: string;
+  children?: React.ReactNode;
 }


### PR DESCRIPTION
In the projects we use React 18, there is a children type error in the Quarkify implementation. As we know, React 18 stops adding this type automatically. That's why I added the missing types.

Detail: https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-typescript-definitions